### PR TITLE
install jq and zip with apt-get

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,8 @@ ENV GOOGLE_DIR=/google \
 WORKDIR ${GOOGLE_DIR}
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
+  jq \
+  zip \
   python \
   && curl -SLO "https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-${GCLOUD_BINARY_VERSION}-linux-x86_64.tar.gz" \
   && tar -xzf "google-cloud-sdk-${GCLOUD_BINARY_VERSION}-linux-x86_64.tar.gz" \


### PR DESCRIPTION
I assume we DO need to install jq and zip. ~~I assume we DON'T need to install sed?~~ Based on running the container locally, we do not seem to need to install sed